### PR TITLE
Test & fix the Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,13 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
-          generate_release_notes: true
-          discussion_category_name: announcements
           name: ${{ github.ref_name }}
+          discussion_category_name: announcements
+          generate_release_notes: true
+          body: -|
+            Get the Docker image at [https://github.com/multani/firestore-emulator/pkgs/container/firestore-emulator/](ghcr.io/multani/firestore-emulator:${{ github.ref_name }})
+
+            ```
+            $ docker pull ghcr.io/multani/firestore-emulator:v1.22.0
+            ```
+            ---

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+    pull_requests:
+      - main
+    branches:
+      - "**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test Docker image
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build
+        working-directory: tests
+        run: docker compose build
+
+      - name: Start
+        working-directory: tests
+        run: docker compose up -d
+
+      - name: Check
+        working-directory: tests
+        run: ./check.sh
+
+      - name: Cleaning up
+        working-directory: tests
+        if: always()
+        run: docker compose down

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   push:
     pull_requests:
       - main
-    branches:
-      - "**"
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-alpine
+FROM node:lts-alpine
 
 RUN apk add openjdk17-jre-headless
 

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+is_running=0
+sleep_time=5
+max_tries=10
+firestore_url="http://localhost:8080"
+nb_success=0
+expected_success=3
+
+for i in $(seq "$max_tries")
+do
+  echo "## Starting check ($i/$max_tries)"
+
+  pid="$(docker compose ps --status=running --quiet)"
+
+  if [ $is_running == 0 ]
+  then
+    if [ -z "$pid" ]
+    then
+      echo "Still not running, trying again in $sleep_time seconds..."
+      sleep $sleep_time
+      continue
+    fi
+
+    is_running=1
+  else
+    if [ -z "$pid" ]
+    then
+      echo "Container was running, but not anymore, maybe it crashed?"
+      echo "Logs:"
+      echo "==============="
+      docker compose logs
+      echo "==============="
+      exit 255
+    fi
+  fi
+
+  echo "Container is running"
+
+  echo "Trying to poll the Firestore endpoint"
+
+  output="$(curl --silent --fail --location --include $firestore_url)"
+  return_code=$?
+
+  echo "Firestore endpoint at $firestore_url returned (code=$return_code):"
+  echo "==============="
+  echo "$output"
+  echo "==============="
+
+  if [ $return_code == 0 ]
+  then
+    echo "Considering this as a success!"
+    nb_success=$((nb_success + 1))
+    echo "Successfully checked $nb_success/$expected_success."
+
+    if [ $nb_success == $expected_success ]
+    then
+      echo "It ran long enough, it seems to be working!"
+      exit 0
+    fi
+
+    # Check several times to be sure it's stable.
+    echo "Checking once more in $sleep_time seconds"
+    sleep $sleep_time
+    continue
+  fi
+
+  echo "Firestore endpoint seemed to have returned an error, trying again in $sleep_time seconds..."
+  sleep $sleep_time
+done

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  firebase:
+    build: ..
+    tty: true
+    ports:
+      - 4000:4000 # UI
+      - 4500:4500 # Logging via websocket
+      - 8080:8080 # Firestore


### PR DESCRIPTION
The current image is broken, apparently due [to a version of Node JS too recent](https://github.com/firebase/firebase-tools-ui/issues/933).

The buggy version used to start, the Firestore endpoint was available for a short time, but then the UI would crash and take down the whole container.

The test tries to work around that verifies:

* The Docker image starts, and stay started
* The Firestore endpoint returns successfully several times

Example of a failing test: https://github.com/multani/firestore-emulator/actions/runs/4523735220
![image](https://user-images.githubusercontent.com/65311/227765587-cf2d87fa-48e1-488e-8ad3-7dd4ed2e1467.png)

A successful test returns:
![image](https://user-images.githubusercontent.com/65311/227765611-e7abcff8-b287-44d2-8525-6f66a1f472fe.png)
